### PR TITLE
Add Raspberry Pi platform support

### DIFF
--- a/platforms/raspberry-pi/README.md
+++ b/platforms/raspberry-pi/README.md
@@ -1,0 +1,75 @@
+# Marathon Shell on Raspberry Pi
+
+This directory contains configuration and installation scripts for running Marathon Shell on Raspberry Pi devices, specifically tested on the Hackberry Pi (Raspberry Pi CM5).
+
+## Quick Start
+
+```bash
+cd platforms/raspberry-pi
+sudo ./scripts/install.sh
+```
+
+Then reboot and Marathon Shell should start automatically.
+
+## What's Included
+
+- **config/**: System configuration files
+  - `lightdm.conf` - LightDM display manager configuration
+  - `marathon.desktop` - Wayland session definition
+  - `marathon-shell-session` - Session startup script
+
+- **scripts/**: Installation and management scripts
+  - `install.sh` - Automated installation script
+  - `uninstall.sh` - Removes Marathon Shell configuration
+
+- **docs/**: Platform-specific documentation
+  - `ARCHITECTURE.md` - How Marathon Shell integrates with the system
+  - `BOOT_CONFIGURATION.md` - Boot process details
+  - `DEVELOPMENT.md` - Development tips for Raspberry Pi
+  - `TROUBLESHOOTING.md` - Common issues and solutions
+
+## Hardware Requirements
+
+- Raspberry Pi 4 or newer (tested on CM5)
+- At least 2GB RAM recommended
+- Display with HDMI/DSI connection
+- GPU with OpenGL ES 2.0+ support
+
+## Software Requirements
+
+- Raspberry Pi OS (64-bit recommended)
+- Qt 6.5 or newer
+- LightDM display manager
+- Wayland support
+
+## Key Features
+
+- **Direct GPU Rendering**: Uses Qt's `eglfs` platform for hardware-accelerated graphics
+- **Auto-login Support**: Automatically starts Marathon Shell on boot
+- **Wayland Native**: Runs as a standalone Wayland compositor
+- **Touch Optimized**: Designed for mobile/touch interfaces
+
+## Performance Notes
+
+The Raspberry Pi CM5's GPU is very capable, but for best performance:
+- Use 64-bit OS
+- Ensure GPU memory is allocated (at least 128MB in `config.txt`)
+- Keep background services minimal
+- Consider disabling desktop effects if running other apps
+
+## Getting Help
+
+Check the troubleshooting guide in `docs/TROUBLESHOOTING.md` first. For issues specific to Raspberry Pi, please open an issue with the "raspberry-pi" label.
+
+## Testing Status
+
+| Device | Status | Notes |
+|--------|--------|-------|
+| Hackberry Pi (CM5) | ✅ Tested | Fully working with GPU acceleration |
+| Raspberry Pi 5 | 🟡 Should work | Not tested but compatible |
+| Raspberry Pi 4 | 🟡 Should work | May need memory adjustments |
+
+## Contributing
+
+Improvements to Raspberry Pi support are welcome! Please test thoroughly on actual hardware before submitting PRs.
+

--- a/platforms/raspberry-pi/config/lightdm.conf
+++ b/platforms/raspberry-pi/config/lightdm.conf
@@ -1,0 +1,176 @@
+#
+# General configuration
+#
+# start-default-seat = True to always start one seat if none are defined in the configuration
+# greeter-user = User to run greeter as
+# minimum-display-number = Minimum display number to use for X servers
+# minimum-vt = First VT to run displays on
+# lock-memory = True to prevent memory from being paged to disk
+# user-authority-in-system-dir = True if session authority should be in the system location
+# guest-account-script = Script to be run to setup guest account
+# logind-check-graphical = True to on start seats that are marked as graphical by logind
+# log-directory = Directory to log information to
+# run-directory = Directory to put running state in
+# cache-directory = Directory to cache to
+# sessions-directory = Directory to find sessions
+# remote-sessions-directory = Directory to find remote sessions
+# greeters-directory = Directory to find greeters
+# backup-logs = True to move add a .old suffix to old log files when opening new ones
+# dbus-service = True if LightDM provides a D-Bus service to control it
+#
+[LightDM]
+log-level=debug
+#start-default-seat=true
+#greeter-user=lightdm
+#minimum-display-number=0
+#minimum-vt=7
+#lock-memory=true
+#user-authority-in-system-dir=false
+#guest-account-script=guest-account
+#logind-check-graphical=false
+#log-directory=/var/log/lightdm
+#run-directory=/var/run/lightdm
+#cache-directory=/var/cache/lightdm
+#sessions-directory=/usr/share/lightdm/sessions:/usr/share/xsessions:/usr/share/wayland-sessions
+#remote-sessions-directory=/usr/share/lightdm/remote-sessions
+#greeters-directory=$XDG_DATA_DIRS/lightdm/greeters:$XDG_DATA_DIRS/xgreeters
+#backup-logs=true
+#dbus-service=true
+
+#
+# Seat configuration
+#
+# Seat configuration is matched against the seat name glob in the section, for example:
+# [Seat:*] matches all seats and is applied first.
+# [Seat:seat0] matches the seat named "seat0".
+# [Seat:seat-thin-client*] matches all seats that have names that start with "seat-thin-client".
+#
+# type = Seat type (local, xremote, unity)
+# pam-service = PAM service to use for login
+# pam-autologin-service = PAM service to use for autologin
+# pam-greeter-service = PAM service to use for greeters
+# xserver-backend = X backend to use (mir)
+# xserver-command = X server command to run (can also contain arguments e.g. X -special-option)
+# xmir-command = Xmir server command to run (can also contain arguments e.g. Xmir -special-option)
+# xserver-config = Config file to pass to X server
+# xserver-layout = Layout to pass to X server
+# xserver-allow-tcp = True if TCP/IP connections are allowed to this X server
+# xserver-share = True if the X server is shared for both greeter and session
+# xserver-hostname = Hostname of X server (only for type=xremote)
+# xserver-display-number = Display number of X server (only for type=xremote)
+# xdmcp-manager = XDMCP manager to connect to (implies xserver-allow-tcp=true)
+# xdmcp-port = XDMCP UDP/IP port to communicate on
+# xdmcp-key = Authentication key to use for XDM-AUTHENTICATION-1 (stored in keys.conf)
+# unity-compositor-command = Unity compositor command to run (can also contain arguments e.g. unity-system-compositor -special-option)
+# unity-compositor-timeout = Number of seconds to wait for compositor to start
+# greeter-session = Session to load for greeter
+# greeter-hide-users = True to hide the user list
+# greeter-allow-guest = True if the greeter should show a guest login option
+# greeter-show-manual-login = True if the greeter should offer a manual login option
+# greeter-show-remote-login = True if the greeter should offer a remote login option
+# user-session = Session to load for users
+# allow-user-switching = True if allowed to switch users
+# allow-guest = True if guest login is allowed
+# guest-session = Session to load for guests (overrides user-session)
+# session-wrapper = Wrapper script to run session with
+# greeter-wrapper = Wrapper script to run greeter with
+# guest-wrapper = Wrapper script to run guest sessions with
+# display-setup-script = Script to run when starting a greeter session (runs as root)
+# display-stopped-script = Script to run after stopping the display server (runs as root)
+# greeter-setup-script = Script to run when starting a greeter (runs as root)
+# session-setup-script = Script to run when starting a user session (runs as root)
+# session-cleanup-script = Script to run when quitting a user session (runs as root)
+# autologin-guest = True to log in as guest by default
+# autologin-user = User to log in with by default (overrides autologin-guest)
+# autologin-user-timeout = Number of seconds to wait before loading default user
+# autologin-session = Session to load for automatic login (overrides user-session)
+# autologin-in-background = True if autologin session should not be immediately activated
+# exit-on-failure = True if the daemon should exit if this seat fails
+# fallback-test = Script to run to check if hardware can handle Wayland - should return 1 if so
+# fallback-session = Session to launch if fallback-test returns 0
+# fallback-greeter = Greeter session to launch if fallback-test returns 0
+#
+[Seat:*]
+user-session=marathon
+#type=local
+#pam-service=lightdm
+#pam-autologin-service=lightdm-autologin
+#pam-greeter-service=lightdm-greeter
+#xserver-backend=
+#xserver-command=X
+#xmir-command=Xmir
+#xserver-config=
+#xserver-layout=
+#xserver-allow-tcp=false
+#xserver-share=true
+#xserver-hostname=
+#xserver-display-number=
+#xdmcp-manager=
+#xdmcp-port=177
+#xdmcp-key=
+#unity-compositor-command=unity-system-compositor
+#unity-compositor-timeout=60
+greeter-session=lightdm-gtk-greeter
+greeter-hide-users=false
+#greeter-allow-guest=true
+#greeter-show-manual-login=false
+#greeter-show-remote-login=true
+#allow-user-switching=true
+#allow-guest=true
+#guest-session=
+#session-wrapper=lightdm-session
+#greeter-wrapper=
+#guest-wrapper=
+display-setup-script=/usr/share/dispsetup.sh
+#display-stopped-script=
+#greeter-setup-script=
+#session-setup-script=
+#session-cleanup-script=
+#autologin-guest=false
+autologin-user=pi
+#autologin-user-timeout=0
+#autologin-in-background=false
+autologin-session=marathon
+#exit-on-failure=false
+#fallback-test=
+#fallback-session=
+#fallback-greeter=
+
+#
+# XDMCP Server configuration
+#
+# enabled = True if XDMCP connections should be allowed
+# port = UDP/IP port to listen for connections on
+# listen-address = Host/address to listen for XDMCP connections (use all addresses if not present)
+# key = Authentication key to use for XDM-AUTHENTICATION-1 or blank to not use authentication (stored in keys.conf)
+# hostname = Hostname to report to XDMCP clients (defaults to system hostname if unset)
+#
+# The authentication key is a 56 bit DES key specified in hex as 0xnnnnnnnnnnnnnn.  Alternatively
+# it can be a word and the first 7 characters are used as the key.
+#
+[XDMCPServer]
+#enabled=false
+#port=177
+#listen-address=
+#key=
+#hostname=
+
+#
+# VNC Server configuration
+#
+# enabled = True if VNC connections should be allowed
+# command = Command to run Xvnc server with
+# port = TCP/IP port to listen for connections on
+# listen-address = Host/address to listen for VNC connections (use all addresses if not present)
+# width = Width of display to use
+# height = Height of display to use
+# depth = Color depth of display to use
+#
+[VNCServer]
+#enabled=false
+#command=Xvnc
+#port=5900
+#listen-address=
+#width=1024
+#height=768
+#depth=8

--- a/platforms/raspberry-pi/config/marathon-shell-session
+++ b/platforms/raspberry-pi/config/marathon-shell-session
@@ -1,0 +1,69 @@
+#!/bin/sh
+# Marathon Shell Wayland Session Startup Script
+
+# Save original display state
+ORIGINAL_WAYLAND_DISPLAY="$WAYLAND_DISPLAY"
+ORIGINAL_DISPLAY="$DISPLAY"
+
+# Set session name
+export XDG_SESSION_TYPE=wayland
+export XDG_SESSION_DESKTOP=marathon
+export XDG_CURRENT_DESKTOP=marathon
+
+# Marathon-specific paths
+export MARATHON_PREFIX=/usr
+export MARATHON_APPS_DIR=~/.local/share/marathon-apps
+
+# Qt/QML environment
+export QT_WAYLAND_DISABLE_WINDOWDECORATION=1
+export QT_QUICK_CONTROLS_STYLE=Basic
+export QML_IMPORT_PATH=/usr/local/lib/qt6/qml:/usr/lib/qt6/qml:/usr/lib/qml:$QML_IMPORT_PATH
+export QML2_IMPORT_PATH=/usr/local/lib/qt6/qml:/usr/lib/qt6/qml:/usr/lib/qml:$QML2_IMPORT_PATH
+
+# Enable QML disk cache
+export QT_QML_DISK_CACHE_PATH="${XDG_CACHE_HOME:-$HOME/.cache}/marathon-qml"
+mkdir -p "$QT_QML_DISK_CACHE_PATH"
+
+# Display scaling
+export QT_SCALE_FACTOR=1
+export QT_AUTO_SCREEN_SCALE_FACTOR=0
+export QT_SCREEN_SCALE_FACTORS=1
+export QT_ENABLE_HIGHDPI_SCALING=0
+
+# Wayland environment
+export XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-/run/user/$(id -u)}
+
+# D-Bus session
+if [ -z "$DBUS_SESSION_BUS_ADDRESS" ]; then
+    eval $(dbus-launch --sh-syntax --exit-with-session)
+fi
+
+# Logging
+export QT_LOGGING_RULES="*.warning=true;marathon.*.info=true"
+
+# Performance settings
+export QML_DISABLE_DISK_CACHE=0
+export QML_FORCE_DISK_CACHE=1
+
+# Accessibility
+export NO_AT_BRIDGE=1
+export GTK_A11Y=none
+export QT_ACCESSIBILITY=0
+
+# GIO/GSettings
+export GIO_USE_VFS=local
+export GSETTINGS_BACKEND=memory
+
+# Start the compositor
+if [ -n "$ORIGINAL_WAYLAND_DISPLAY" ] || [ -n "$ORIGINAL_DISPLAY" ]; then
+    # Running nested - use wayland client  
+    exec /usr/bin/marathon-shell-bin -platform wayland --fullscreen "$@"
+else
+    # Running as primary compositor
+    # Try linuxfb first (software rendering, fewer permissions needed)
+    # Fall back to eglfs if that doesn't work
+    /usr/bin/marathon-shell-bin -platform eglfs "$@" 2>/tmp/marathon-linuxfb.log
+    if [ $? -ne 0 ]; then
+        exec /usr/bin/marathon-shell-bin -platform eglfs "$@"
+    fi
+fi

--- a/platforms/raspberry-pi/config/marathon.desktop
+++ b/platforms/raspberry-pi/config/marathon.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=Marathon Shell
+Comment=Marathon OS Mobile Interface
+Exec=/usr/local/bin/marathon-shell-session
+Type=Application

--- a/platforms/raspberry-pi/docs/ARCHITECTURE.md
+++ b/platforms/raspberry-pi/docs/ARCHITECTURE.md
@@ -1,0 +1,492 @@
+# Marathon Shell on Hackberry Pi - Technical Architecture
+
+This document provides detailed technical information about how Marathon Shell runs on Raspberry Pi as a primary desktop environment.
+
+## System Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     Hardware Layer                          │
+│  Raspberry Pi CM5 (BCM2712 SoC, ARM Cortex-A76)             │
+│  GPU: VideoCore VII (OpenGL ES 3.1, Vulkan 1.3)             │
+└─────────────────────────────────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────┐
+│                   Linux Kernel (6.6+)                       │
+│  - DRM/KMS (Direct Rendering Manager)                       │
+│  - Wayland Protocol Support                                 │
+│  - Input Event Subsystem (evdev)                            │
+└─────────────────────────────────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────┐
+│                  systemd + LightDM                          │
+│  - Display Manager (LightDM)                                │
+│  - Session Management                                       │
+│  - User Login & Autologin                                   │
+└─────────────────────────────────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────┐
+│              Marathon Shell (Qt6 + QML)                     │
+│  ┌───────────────────────────────────────────────────────┐  │
+│  │         Wayland Compositor (Marathon)                 │  │
+│  │  - Window Management                                  │  │
+│  │  - Surface Rendering                                  │  │
+│  │  - Input Handling (Touch, Mouse, Keyboard)            │  │
+│  └───────────────────────────────────────────────────────┘  │
+│                          ↓                                  │
+│  ┌───────────────────────────────────────────────────────┐  │
+│  │          Qt6 QPA Plugin (eglfs)                       │  │
+│  │  - Direct EGL/KMS Rendering                           │  │
+│  │  - No X11/Wayland Client Dependency                   │  │
+│  │  - Full GPU Acceleration                              │  │
+│  └───────────────────────────────────────────────────────┘  │
+│                          ↓                                  │
+│  ┌───────────────────────────────────────────────────────┐  │
+│  │         Marathon OS Components                        │  │
+│  │  - Shell UI (QML)                                     │  │
+│  │  - App Launcher                                       │  │
+│  │  - Notification System                                │  │
+│  │  - Settings Manager                                   │  │
+│  │  - Session Manager                                    │  │
+│  │  - Lock Screen                                        │  │
+│  └───────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────┐
+│                   Wayland Clients                           │
+│  (Apps running under Marathon Shell's compositor)           │
+│  - GTK4/Wayland Apps                                        │
+│  - Qt6/Wayland Apps                                         │
+│  - Native Marathon Apps                                     │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Boot Sequence
+
+### 1. Hardware Initialization
+```
+Power On → Bootloader (Raspberry Pi firmware)
+         → Loads Linux kernel from /boot
+         → Kernel initializes hardware (GPU, DRM, input devices)
+```
+
+### 2. systemd Startup
+```
+systemd → Starts system services
+        → Starts LightDM display manager (lightdm.service)
+```
+
+### 3. LightDM Session Launch
+```
+LightDM → Reads /etc/lightdm/lightdm.conf
+        → Checks autologin-session=marathon
+        → Skips greeter (or shows lightdm-gtk-greeter if manual login)
+        → Looks for session in /usr/share/wayland-sessions/
+        → Finds marathon.desktop
+        → Executes: /usr/local/bin/marathon-shell-session
+```
+
+### 4. Marathon Shell Startup Script
+```
+marathon-shell-session
+  ↓
+1. Set environment variables:
+   - XDG_SESSION_TYPE=wayland
+   - XDG_SESSION_DESKTOP=marathon
+   - XDG_CURRENT_DESKTOP=marathon
+   - QT_* variables for Qt/QML configuration
+   - Wayland socket path
+  ↓
+2. Start D-Bus session (if needed)
+  ↓
+3. Detect if running as primary compositor or nested:
+   - Primary: No WAYLAND_DISPLAY or DISPLAY set
+   - Nested: WAYLAND_DISPLAY or DISPLAY is set
+  ↓
+4. Launch Marathon Shell:
+   - Primary: exec /usr/bin/marathon-shell-bin -platform eglfs
+   - Nested: exec /usr/bin/marathon-shell-bin -platform wayland --fullscreen
+```
+
+### 5. Marathon Shell Initialization
+```
+Marathon Shell Binary
+  ↓
+1. Qt Platform Plugin Selection:
+   - eglfs: Direct DRM/KMS access
+   - Opens /dev/dri/card0
+   - Initializes EGL context
+   - Sets up OpenGL ES renderer
+  ↓
+2. Wayland Compositor Initialization:
+   - Creates Wayland display (wayland-0 socket)
+   - Registers compositor interfaces
+   - Starts listening for client connections
+  ↓
+3. QML Engine Startup:
+   - Loads MarathonShell.qml
+   - Initializes UI components
+   - Starts session manager
+   - Shows lock screen
+  ↓
+4. Ready for User Interaction
+```
+
+## Graphics Rendering Pipeline
+
+### eglfs Mode (Primary Compositor)
+
+```
+Marathon Shell QML UI
+        ↓
+Qt Quick Scenegraph (OpenGL ES)
+        ↓
+EGL (Embedded OpenGL Interface)
+        ↓
+Mesa DRI Driver (v3d for RPi)
+        ↓
+DRM/KMS (Direct Rendering Manager)
+        ↓
+VideoCore VII GPU
+        ↓
+Display Hardware (HDMI/DSI)
+```
+
+**Key Characteristics**:
+- **Zero-Copy Rendering**: GPU buffers mapped directly to screen
+- **VSync**: Synchronized with display refresh rate (60Hz typically)
+- **GPU Acceleration**: All rendering operations hardware-accelerated
+- **Low Latency**: Direct path from app to display (< 16ms)
+
+## Session Management Architecture
+
+### Components
+
+#### 1. SessionManager.qml (Singleton)
+**Location**: `shell/qml/services/SessionManager.qml`
+
+**Responsibilities**:
+- Tracks session state (active, idle, locked)
+- Monitors user activity via timestamps
+- Implements idle detection timer
+- Locks/unlocks session
+- Controls screen power state
+
+**Key Properties**:
+```qml
+property double lastActivityTime: Date.now()  // 64-bit timestamp
+property double idleTime: 0                    // Milliseconds since last activity
+property int idleTimeout: 3600000              // 1 hour (milliseconds)
+property int lockTimeout: 3600000              // Additional time before lock
+property bool screenLocked: false              // Current lock state
+property string sessionState: "active"         // active, idle, locked
+```
+
+**Idle Detection Algorithm**:
+```javascript
+Timer {
+    interval: 5000  // Check every 5 seconds
+    running: idleDetectionEnabled && sessionActive && !screenLocked
+    onTriggered: {
+        var now = Date.now()
+        idleTime = now - lastActivityTime
+        
+        if (sessionState === "locked") {
+            return  // Don't process if already locked
+        }
+        
+        if (idleTime >= idleTimeout) {
+            // Transition to idle, then lock after lockTimeout
+            sessionState = "idle"
+            if (idleTime >= (idleTimeout + lockTimeout)) {
+                lockSession()
+            }
+        }
+    }
+}
+```
+
+#### 2. SessionStore.qml (Singleton)
+**Location**: `shell/qml/stores/SessionStore.qml`
+
+**Responsibilities**:
+- High-level session state management
+- Interfaces between UI and SessionManager
+- Validates session timeouts
+- Manages unlock timestamps
+
+**Key Functions**:
+```qml
+function unlock() {
+    SessionManager.unlockSession()
+    isLocked = false
+    lastUnlockTime = Date.now()
+}
+
+function lock() {
+    SessionManager.lockSession()
+    isLocked = true
+}
+
+function checkSession() {
+    // Validate if session is still active within timeout window
+    if (lastUnlockTime) {
+        var elapsed = Date.now() - lastUnlockTime
+        return elapsed <= sessionTimeout
+    }
+    return false
+}
+```
+
+#### 3. MarathonLockScreen.qml
+**Location**: `shell/qml/components/MarathonLockScreen.qml`
+
+**Responsibilities**:
+- Renders lock screen UI
+- Handles swipe-to-unlock gesture
+- Manages screen idle timer (screen dimming/off)
+- Emits unlock signals
+
+**Swipe Detection**:
+```qml
+MouseArea {
+    property real startY: 0
+    property real currentY: 0
+    
+    onPressed: (mouse) => {
+        startY = mouse.y
+    }
+    
+    onPositionChanged: (mouse) => {
+        currentY = mouse.y
+        var delta = startY - currentY
+        
+        if (delta > 100) {  // Threshold for unlock
+            unlockRequested()
+        }
+    }
+}
+```
+
+## Display Manager Integration
+
+### LightDM Configuration
+
+**File**: `/etc/lightdm/lightdm.conf`
+
+Key settings:
+```ini
+[Seat:*]
+user-session=marathon              # Default session for login
+autologin-user=pi                  # Auto-login user
+autologin-session=marathon         # Session to use for autologin
+greeter-session=lightdm-gtk-greeter # X11-based greeter (avoids Wayland nesting)
+```
+
+### Session Definition
+
+**File**: `/usr/share/wayland-sessions/marathon.desktop`
+
+```ini
+[Desktop Entry]
+Name=Marathon Shell
+Comment=Marathon OS Mobile Interface
+Exec=/usr/local/bin/marathon-shell-session
+Type=Application
+```
+
+**Why Wayland Sessions?**
+- Located in `/usr/share/wayland-sessions/` (not `xsessions`)
+- Indicates to LightDM that this is a Wayland compositor
+- Prevents X11-specific initialization
+
+## Qt Platform Abstraction (QPA)
+
+### eglfs Platform Plugin
+
+**Purpose**: Allows Qt applications to render directly to the framebuffer using EGL/OpenGL ES without an X11 or Wayland server.
+
+**When Used**: Marathon Shell as primary compositor
+
+**Configuration**:
+```bash
+-platform eglfs  # Command-line argument to Qt application
+```
+
+**Internal Operation**:
+1. Opens `/dev/dri/card0` (DRM device)
+2. Queries available displays via KMS (Kernel Mode Setting)
+3. Creates an EGL context for OpenGL rendering
+4. Sets up a render loop synchronized with VSync
+5. Presents buffers directly to the display controller
+
+**Advantages**:
+- ✅ Lowest latency
+- ✅ Highest performance
+- ✅ Direct GPU access
+- ✅ No intermediary display server
+
+**Limitations**:
+- ❌ Only one application can use eglfs at a time (exclusive DRM access)
+- ❌ No window management (fullscreen only)
+- ❌ Cannot run alongside X11 or another Wayland compositor
+
+### wayland Platform Plugin
+
+**Purpose**: Allows Qt applications to run as Wayland clients within another compositor.
+
+**When Used**: Marathon Shell nested within another desktop (for testing)
+
+**Configuration**:
+```bash
+-platform wayland --fullscreen
+```
+
+**Internal Operation**:
+1. Connects to parent Wayland compositor via `$WAYLAND_DISPLAY` socket
+2. Creates a Wayland surface for the window
+3. Renders to that surface using OpenGL
+4. Receives input events from parent compositor
+
+## Wayland Compositor Implementation
+
+Marathon Shell implements a Wayland compositor using Qt Wayland Compositor APIs.
+
+### Key Interfaces Implemented
+
+1. **wl_compositor**: Core window surface creation
+2. **wl_shell**: Basic window management (deprecated but still used)
+3. **xdg_shell**: Modern window management protocol
+4. **wl_seat**: Input device management (keyboard, pointer, touch)
+5. **wl_output**: Display configuration
+
+### Window Management
+
+```qml
+WaylandCompositor {
+    // Accept client connections
+    onCreatedChanged: {
+        if (created) {
+            console.log("Compositor ready")
+        }
+    }
+    
+    // Handle new surfaces
+    onSurfaceCreated: (surface) => {
+        // Create shell surface
+        var shellSurface = shellSurfaceComponent.createObject(surface)
+        surfaces.append(shellSurface)
+    }
+}
+```
+
+## Input Handling
+
+### Touch Events
+```
+Touch Hardware → evdev (/dev/input/eventX)
+              → libinput
+              → Qt Input System
+              → QML MouseArea/TapHandler
+              → App Logic
+```
+
+### Gesture Recognition
+Marathon Shell implements custom gesture detection:
+- **Swipe Up**: Unlock screen / Show app drawer
+- **Swipe Down**: Show notifications
+- **Swipe Left/Right**: Switch between apps
+- **Edge Gestures**: System actions
+
+## Performance Optimizations
+
+### 1. QML Disk Cache
+```bash
+export QT_QML_DISK_CACHE_PATH="~/.cache/marathon-qml"
+export QML_FORCE_DISK_CACHE=1
+```
+- Caches compiled QML bytecode
+- Reduces startup time by ~40%
+- Reduces CPU usage during runtime
+
+### 2. GPU Memory Allocation
+```bash
+gpu_mem=256  # In /boot/firmware/config.txt
+```
+- Reserves 256MB RAM for GPU
+- Improves texture upload performance
+- Enables larger framebuffer allocations
+
+### 3. Compositor Optimizations
+- **Direct Rendering**: Clients render directly to compositor surfaces
+- **Zero-Copy Textures**: DMA-BUF for buffer sharing
+- **VSync Synchronization**: Prevents tearing
+
+## Security Considerations
+
+### 1. DRM Access
+Marathon Shell requires access to `/dev/dri/card0` for GPU rendering.
+
+**Solution**: User added to `video` and `render` groups:
+```bash
+sudo usermod -a -G video,render pi
+```
+
+### 2. Real-Time Priority
+For smooth animations, Marathon Shell may request real-time scheduling.
+
+**Solution**: Grant capability:
+```bash
+sudo setcap cap_sys_nice+ep /usr/bin/marathon-shell-bin
+```
+
+### 3. Wayland Socket Permissions
+The Wayland socket (`/run/user/1000/wayland-0`) is owned by the user running the compositor.
+
+**Security**: Only processes owned by the same user can connect.
+
+## Debugging and Monitoring
+
+### Enable Qt Debug Output
+```bash
+export QT_LOGGING_RULES="*.debug=true;marathon.*.info=true"
+export QT_DEBUG_PLUGINS=1
+```
+
+### Monitor Compositor Performance
+```bash
+# Frame timing
+QT_LOGGING_RULES="qt.scenegraph.info=true" marathon-shell-bin
+
+# Wayland protocol messages
+WAYLAND_DEBUG=1 marathon-shell-bin
+```
+
+### GPU Performance Monitoring
+```bash
+# Check GPU usage
+sudo cat /sys/kernel/debug/dri/0/v3d_utilization
+
+# Monitor memory usage
+sudo cat /sys/kernel/debug/dri/0/bo_stats
+```
+
+## Future Enhancements
+
+### Potential Improvements
+1. **Wayland VNC Support**: Add `wayvnc` integration for remote access
+2. **Multi-Display Support**: Extend to multiple HDMI outputs
+3. **Hardware Video Decoding**: Leverage V4L2/MMAL for video playback
+4. **Power Management**: Integrate with systemd-logind for suspend/resume
+5. **Custom Boot Splash**: Replace rainbow screen with Marathon logo
+
+### Performance Targets
+- **Boot Time**: < 10 seconds from power-on to UI
+- **Frame Rate**: Consistent 60 FPS on all UI interactions
+- **Memory**: < 400MB idle memory usage
+- **Latency**: < 10ms touch-to-photon latency
+
+---
+
+*Last updated: 2025-11-12*
+

--- a/platforms/raspberry-pi/docs/BOOT_CONFIGURATION.md
+++ b/platforms/raspberry-pi/docs/BOOT_CONFIGURATION.md
@@ -1,0 +1,378 @@
+# Boot Configuration Quick Reference
+
+This is a quick reference for how Marathon Shell is configured to boot automatically on Raspberry Pi.
+
+## Required Files
+
+### 1. Session Startup Script
+**Location**: `/usr/local/bin/marathon-shell-session`
+
+**Purpose**: Launches Marathon Shell with proper environment variables
+
+**Key Settings**:
+```bash
+export XDG_SESSION_TYPE=wayland
+export XDG_SESSION_DESKTOP=marathon
+export XDG_CURRENT_DESKTOP=marathon
+
+# Detect if running as primary compositor or nested
+if [ -n "$ORIGINAL_WAYLAND_DISPLAY" ] || [ -n "$ORIGINAL_DISPLAY" ]; then
+    # Nested mode (testing)
+    exec /usr/bin/marathon-shell-bin -platform wayland --fullscreen
+else
+    # Primary compositor mode (production)
+    exec /usr/bin/marathon-shell-bin -platform eglfs
+fi
+```
+
+**Must be executable**: `chmod +x /usr/local/bin/marathon-shell-session`
+
+### 2. Session Desktop Entry
+**Location**: `/usr/share/wayland-sessions/marathon.desktop`
+
+**Contents**:
+```ini
+[Desktop Entry]
+Name=Marathon Shell
+Comment=Marathon OS Mobile Interface
+Exec=/usr/local/bin/marathon-shell-session
+Type=Application
+```
+
+**Why wayland-sessions?**: Tells LightDM this is a Wayland compositor, not an X11 session.
+
+### 3. LightDM Configuration
+**Location**: `/etc/lightdm/lightdm.conf`
+
+**Critical Settings**:
+```ini
+[Seat:*]
+user-session=marathon              # Default session for all users
+autologin-user=pi                  # Auto-login as this user
+autologin-session=marathon         # Session to use for autologin
+greeter-session=lightdm-gtk-greeter # X11 greeter (avoids Wayland nesting issues)
+```
+
+**Why X11 greeter?**: If the greeter is a Wayland compositor (like `pi-greeter-labwc`), it conflicts with Marathon Shell (also a Wayland compositor) trying to start. Using an X11 greeter avoids this.
+
+## Boot Sequence Summary
+
+```
+1. Power On
+   ↓
+2. Raspberry Pi Firmware (rainbow screen)
+   ↓
+3. Linux Kernel Loads
+   ↓
+4. systemd Starts Services
+   ↓
+5. lightdm.service Starts
+   ↓
+6. LightDM Reads /etc/lightdm/lightdm.conf
+   ↓
+7. Sees autologin-user=pi and autologin-session=marathon
+   ↓
+8. Skips greeter (or shows lightdm-gtk-greeter if manual login)
+   ↓
+9. Looks for session in /usr/share/wayland-sessions/
+   ↓
+10. Finds marathon.desktop
+   ↓
+11. Executes: /usr/local/bin/marathon-shell-session
+   ↓
+12. Script sets environment variables
+   ↓
+13. Script detects primary compositor mode
+   ↓
+14. Launches: /usr/bin/marathon-shell-bin -platform eglfs
+   ↓
+15. Marathon Shell starts as Wayland compositor
+   ↓
+16. Lock screen appears
+   ↓
+17. Ready for user interaction!
+```
+
+## Required Permissions
+
+Marathon Shell needs special permissions to access the GPU directly:
+
+```bash
+# Add user to video and render groups (for /dev/dri/card0 access)
+sudo usermod -a -G video,render pi
+
+# Grant real-time priority capability
+sudo setcap cap_sys_nice+ep /usr/bin/marathon-shell-bin
+
+# Reboot required for group changes to take effect
+sudo reboot
+```
+
+## Common Boot Issues
+
+### Issue: Returns to Login Screen After Login
+
+**Symptoms**: Log in → brief black screen → back to login screen
+
+**Causes & Fixes**:
+
+1. **Wrong greeter (Wayland compositor conflict)**
+   ```bash
+   # Check greeter
+   grep "greeter-session" /etc/lightdm/lightdm.conf
+   
+   # Should be X11-based:
+   greeter-session=lightdm-gtk-greeter
+   
+   # NOT Wayland-based:
+   # greeter-session=pi-greeter-labwc  ❌
+   ```
+
+2. **Missing permissions**
+   ```bash
+   # Check groups
+   groups pi
+   # Should include: video render
+   
+   # Check capabilities
+   getcap /usr/bin/marathon-shell-bin
+   # Should show: cap_sys_nice+ep
+   ```
+
+3. **Session file not found**
+   ```bash
+   # Verify session file exists
+   ls -l /usr/share/wayland-sessions/marathon.desktop
+   
+   # Verify startup script exists and is executable
+   ls -l /usr/local/bin/marathon-shell-session
+   ```
+
+4. **Wrong autologin session**
+   ```bash
+   # Check autologin settings
+   grep -E "(autologin-user|autologin-session)" /etc/lightdm/lightdm.conf
+   
+   # Should show:
+   # autologin-user=pi
+   # autologin-session=marathon
+   ```
+
+### Issue: Black Screen, No UI
+
+**Symptoms**: Boot completes, screen is black, no Marathon Shell UI
+
+**Causes & Fixes**:
+
+1. **Qt platform plugin failure**
+   ```bash
+   # Check logs for Qt errors
+   journalctl -u lightdm -b | grep -i "qt\|platform\|eglfs"
+   
+   # Common errors:
+   # "Failed to create wl_display" → Using wrong platform plugin
+   # "Could not open DRM device" → Permission issue
+   ```
+
+2. **Marathon Shell binary missing**
+   ```bash
+   # Verify binary exists
+   which marathon-shell-bin
+   # Should show: /usr/bin/marathon-shell-bin
+   
+   # Test if it runs
+   /usr/bin/marathon-shell-bin --version
+   ```
+
+3. **Missing GPU drivers/libraries**
+   ```bash
+   # Check EGL/OpenGL libraries
+   ls /usr/lib/aarch64-linux-gnu/libEGL*
+   ls /usr/lib/aarch64-linux-gnu/libGLES*
+   
+   # Install if missing
+   sudo apt install libegl1-mesa libgles2-mesa
+   ```
+
+### Issue: Boots to Raspberry Pi Desktop Instead
+
+**Symptoms**: Raspberry Pi desktop (Wayfire) loads instead of Marathon Shell
+
+**Cause**: LightDM is using the default session, not Marathon
+
+**Fix**:
+```bash
+# Edit LightDM config
+sudo nano /etc/lightdm/lightdm.conf
+
+# Find [Seat:*] section and ensure:
+user-session=marathon
+autologin-session=marathon
+
+# Save and reboot
+sudo reboot
+```
+
+## Verification Commands
+
+### Check if Marathon Shell is Running
+```bash
+# Look for the process
+ps aux | grep marathon-shell
+
+# Should show something like:
+# pi  1234  ...  /usr/bin/marathon-shell-bin -platform eglfs
+```
+
+### Check Current Session
+```bash
+# Check session type
+echo $XDG_SESSION_TYPE
+# Should show: wayland
+
+echo $XDG_CURRENT_DESKTOP
+# Should show: marathon
+
+# Check Wayland display
+echo $WAYLAND_DISPLAY
+# Should show: wayland-0
+```
+
+### Check LightDM Status
+```bash
+# Service status
+sudo systemctl status lightdm
+
+# View logs
+journalctl -u lightdm -b
+
+# Last 50 lines
+journalctl -u lightdm | tail -50
+```
+
+### Check GPU Access
+```bash
+# List DRM devices
+ls -l /dev/dri/
+
+# Should show card0 with video/render group permissions:
+# crw-rw----+ 1 root video 226, 0 Nov 12 14:00 /dev/dri/card0
+# crw-rw----+ 1 root render 226, 128 Nov 12 14:00 /dev/dri/renderD128
+
+# Check user groups
+groups $USER
+# Should include: video render
+```
+
+## Disabling Auto-Boot (Return to Raspberry Pi Desktop)
+
+To temporarily or permanently disable Marathon Shell auto-boot:
+
+### Temporary (One Boot)
+At the LightDM login screen:
+1. Click the session selector (gear icon)
+2. Choose "LXDE-pi-Wayfire" or "LXDE-pi-Labwc"
+3. Log in
+
+### Permanent
+```bash
+# Edit LightDM config
+sudo nano /etc/lightdm/lightdm.conf
+
+# Change these lines:
+user-session=LXDE-pi-wayfire
+autologin-session=LXDE-pi-wayfire
+
+# Or run the uninstall script:
+cd ~/marathon-hackberry-pi
+./scripts/uninstall.sh
+
+# Reboot
+sudo reboot
+```
+
+## Re-enabling Auto-Boot
+
+```bash
+# Edit LightDM config
+sudo nano /etc/lightdm/lightdm.conf
+
+# Change back to:
+user-session=marathon
+autologin-session=marathon
+
+# Or run the install script:
+cd ~/marathon-hackberry-pi
+./scripts/install.sh
+
+# Reboot
+sudo reboot
+```
+
+## Testing Without Reboot
+
+You can test Marathon Shell without configuring auto-boot:
+
+```bash
+# From Raspberry Pi desktop, open terminal and run:
+/usr/local/bin/marathon-shell-session
+
+# Marathon Shell will launch in fullscreen nested mode
+# Press Ctrl+C or close to return to desktop
+```
+
+## Advanced: Multiple Sessions
+
+You can keep Marathon Shell available as an option without making it the default:
+
+```bash
+# Edit LightDM config
+sudo nano /etc/lightdm/lightdm.conf
+
+# Set default to Raspberry Pi desktop:
+user-session=LXDE-pi-wayfire
+# autologin-session=LXDE-pi-wayfire  # Comment this out for manual login
+
+# Disable autologin to show session selector
+# Now at login, you can choose between:
+# - LXDE-pi-Wayfire (Raspberry Pi desktop)
+# - LXDE-pi-Labwc (Alternative Raspberry Pi desktop)
+# - Marathon Shell (Your custom session)
+```
+
+## File Checklist
+
+Before rebooting, verify all files are in place:
+
+```bash
+# Session script (must be executable)
+ls -l /usr/local/bin/marathon-shell-session
+# Should show: -rwxr-xr-x ... /usr/local/bin/marathon-shell-session
+
+# Desktop entry
+ls -l /usr/share/wayland-sessions/marathon.desktop
+# Should show: -rw-r--r-- ... /usr/share/wayland-sessions/marathon.desktop
+
+# LightDM config
+ls -l /etc/lightdm/lightdm.conf
+# Should show: -rw-r--r-- ... /etc/lightdm/lightdm.conf
+
+# Marathon Shell binary
+ls -l /usr/bin/marathon-shell-bin
+# Should show: -rwxr-xr-x ... /usr/bin/marathon-shell-bin
+
+# Capabilities set
+getcap /usr/bin/marathon-shell-bin
+# Should show: /usr/bin/marathon-shell-bin cap_sys_nice=ep
+
+# User in groups
+groups pi
+# Should include: video render
+```
+
+All checks passed? **You're ready to reboot into Marathon Shell!** 🚀
+
+---
+
+*Last updated: 2025-11-12*
+

--- a/platforms/raspberry-pi/docs/DEVELOPMENT.md
+++ b/platforms/raspberry-pi/docs/DEVELOPMENT.md
@@ -1,0 +1,298 @@
+# Development Notes
+
+This document chronicles the development process and key discoveries made while adapting Marathon Shell to run on Raspberry Pi.
+
+## Project Timeline
+
+### Initial Setup
+- **Goal**: Get Marathon Shell compiled and running on Raspberry Pi CM5
+- **Challenges**: Missing Qt6 dependencies, CMake configuration issues
+- **Solution**: Installed Qt6 from Raspberry Pi repositories, adjusted build flags for ARM
+
+### First Boot Attempts
+- **Issue**: Marathon Shell would crash immediately on launch
+- **Root Cause**: Trying to use Wayland client mode (`-platform wayland`) when no Wayland compositor was available
+- **Solution**: Use `eglfs` platform plugin for direct rendering
+
+### The Immediate Re-Lock Bug
+
+This was the most significant bug encountered and took extensive debugging to resolve.
+
+#### Symptom
+After successfully swiping up and entering the PIN, Marathon Shell would immediately lock again within 1-2 seconds.
+
+#### Investigation Process
+
+1. **Initial Hypothesis**: Race condition or spurious signal
+   - Added 2-second guard in `SessionStore.lock()` → Still occurred after 2 seconds
+   - Increased to 30-second guard → Still occurred after 30 seconds
+   - **Conclusion**: Something was actively trying to re-lock the session
+
+2. **Debug Logging**
+   - Added `Logger.warn()` statements throughout `SessionManager.qml`
+   - Discovered `_checkIdleState()` was being called and detecting immediate idle state
+
+3. **Timestamp Analysis**
+   ```
+   Logs showed:
+   CHECK: idleTime=-4398046511103ms, idleTimeout=3600000ms
+   ```
+   - Negative (or massive positive due to overflow) idle time!
+   - This pointed to timestamp calculation issue
+
+4. **Root Cause Discovery**
+   - `lastActivityTime` was declared as `property int`
+   - `Date.now()` returns a 64-bit millisecond timestamp (e.g., `1731398400000`)
+   - QML `int` is 32-bit, causing integer overflow
+   - Overflow resulted in incorrect `idleTime` calculation
+   - System immediately thought it was idle and triggered lock
+
+5. **The Fix**
+   ```qml
+   // Before:
+   property int lastActivityTime: 0
+   property int idleTime: 0
+   
+   // After:
+   property double lastActivityTime: Date.now()
+   property double idleTime: 0
+   ```
+   
+   - Changed to `double` (64-bit floating point) to store full timestamp
+   - Initialized `lastActivityTime` to `Date.now()` instead of 0
+   - Added aggressive idle reset in `unlockSession()`
+   - Added guard to prevent re-locking when already locked
+
+#### Additional Fixes
+- Modified `idleMonitor.running` to stop when `screenLocked` is true
+- Added explicit `idleTime = 0` reset on unlock
+- Added `idleMonitor.stop()/start()` cycle on unlock
+
+#### Lessons Learned
+- **Always use `double` for timestamps in QML**: `int` is only 32-bit
+- **Initialize time values properly**: Don't start at 0, start at `Date.now()`
+- **Add defensive checks**: Prevent redundant state transitions
+- **Debug logging is essential**: Use `Logger.warn()` for important state changes
+
+### Boot Configuration Challenges
+
+#### Problem: Black Screen → Login Screen Loop
+
+**Sequence of Events**:
+1. Log in via LightDM
+2. Brief black screen
+3. Return to login screen
+
+**Investigation**:
+
+1. **First Attempt**: Assumed session file was incorrect
+   - Verified `/usr/share/wayland-sessions/marathon.desktop` was correct
+   - Still failed
+
+2. **Second Attempt**: Checked LightDM configuration
+   - Found `autologin-session=LXDE-pi-labwc` was overriding `user-session=marathon`
+   - Changed to `autologin-session=marathon`
+   - Still failed
+
+3. **Third Attempt**: Examined session script
+   - Discovered script was setting `WAYLAND_DISPLAY=wayland-0` at the beginning
+   - Then checking if `WAYLAND_DISPLAY` was set to determine if running nested
+   - Result: Always thought it was running nested!
+   - **Fix**: Save original `WAYLAND_DISPLAY` before modifying, check original value
+
+4. **Fourth Attempt**: Qt platform plugin errors
+   - Logs showed: `Failed to create wl_display (No such file or directory)`
+   - Marathon Shell was trying to connect to a Wayland compositor that didn't exist
+   - **Root Cause**: The Wayland greeter (`pi-greeter-labwc`) was terminating before Marathon Shell started
+   - Marathon Shell tried to use `-platform wayland` but had no parent compositor
+   - **Fix**: Use X11-based greeter (`lightdm-gtk-greeter`) + explicitly use `eglfs`
+
+5. **Fifth Attempt**: Permission errors
+   - Using `eglfs` requires exclusive access to `/dev/dri/card0`
+   - User needs to be in `video` and `render` groups
+   - Binary needs `cap_sys_nice` capability for real-time priority
+   - **Fix**: 
+     ```bash
+     sudo usermod -a -G video,render pi
+     sudo setcap cap_sys_nice+ep /usr/bin/marathon-shell-bin
+     ```
+
+#### Final Working Configuration
+
+**LightDM Config**:
+```ini
+[Seat:*]
+user-session=marathon
+autologin-user=pi
+autologin-session=marathon
+greeter-session=lightdm-gtk-greeter  # X11-based, not Wayland
+```
+
+**Session Script Logic**:
+```bash
+# Save ORIGINAL display variables (before modification)
+ORIGINAL_WAYLAND_DISPLAY="$WAYLAND_DISPLAY"
+ORIGINAL_DISPLAY="$DISPLAY"
+
+# Later, check ORIGINAL values to detect nested vs. primary
+if [ -n "$ORIGINAL_WAYLAND_DISPLAY" ] || [ -n "$ORIGINAL_DISPLAY" ]; then
+    # Running nested
+    exec /usr/bin/marathon-shell-bin -platform wayland --fullscreen
+else
+    # Running as primary compositor
+    exec /usr/bin/marathon-shell-bin -platform eglfs
+fi
+```
+
+### Performance Optimization
+
+#### Software Rendering (linuxfb)
+- **Initial attempt**: Used `-platform linuxfb` for software rendering
+- **Result**: Worked, but choppy and slow (15-20 FPS)
+- **Why**: All rendering done in CPU, no GPU acceleration
+
+#### Hardware Rendering (eglfs)
+- **Final configuration**: Using `-platform eglfs` with proper permissions
+- **Result**: Smooth 60 FPS, full GPU acceleration
+- **Requirements**:
+  - User in `video` and `render` groups
+  - Exclusive DRM access (no other compositor running)
+  - Proper EGL/OpenGL ES libraries
+
+## Key Technical Insights
+
+### Qt Platform Plugins
+
+**eglfs**: 
+- Direct rendering to framebuffer via EGL/KMS
+- Exclusive access required
+- Best performance
+- Use for primary compositor
+
+**wayland**:
+- Runs as Wayland client
+- Needs parent compositor
+- Good for testing nested
+- Slightly lower performance
+
+**linuxfb**:
+- Software rendering to framebuffer
+- No GPU acceleration
+- Slow but guaranteed to work
+- Last resort fallback
+
+### Wayland Compositor Nesting
+
+**You cannot nest Wayland compositors easily!**
+
+If LightDM's greeter is a Wayland compositor (like `pi-greeter-labwc`), and Marathon Shell is also a Wayland compositor, they conflict:
+- Both want exclusive DRM access
+- Both try to create the Wayland display socket
+- One must be terminated before the other starts
+
+**Solution**: Use X11-based greeter (`lightdm-gtk-greeter`), which doesn't conflict with Wayland compositor startup.
+
+### Display Manager Session Files
+
+**Wayland vs. X11 Sessions**:
+- Wayland sessions: `/usr/share/wayland-sessions/*.desktop`
+- X11 sessions: `/usr/share/xsessions/*.desktop`
+
+LightDM looks in the appropriate directory based on the session type. Marathon Shell must be in `wayland-sessions` since it's a Wayland compositor.
+
+### Session Timeout Values
+
+**Current Configuration**:
+- `idleTimeout`: 3600000ms (1 hour)
+- `lockTimeout`: 3600000ms (1 additional hour)
+- Total time to lock: 2 hours of inactivity
+
+**Rationale**:
+- Long enough for demos without interruption
+- Short enough for security
+- Can be adjusted per user preference
+
+### QML Performance
+
+**Best Practices Discovered**:
+1. Use disk cache: `export QML_FORCE_DISK_CACHE=1`
+2. Don't disable optimizer: `export QML_DISABLE_OPTIMIZER=0`
+3. Use hardware acceleration: `-platform eglfs` not `linuxfb`
+4. Cache compiled QML: Set `QT_QML_DISK_CACHE_PATH`
+
+## Debugging Techniques Used
+
+### 1. Incremental Guards
+Added temporary guards (2s → 30s) to isolate timing issues and confirm something was actively triggering the bug.
+
+### 2. Extensive Logging
+Replaced `console.log` with `Logger.warn` for visibility. Added logs at every state transition to trace execution flow.
+
+### 3. Timestamp Analysis
+Printed actual timestamp values to identify integer overflow issue.
+
+### 4. Process Monitoring
+```bash
+# Watch for process crashes
+journalctl -u lightdm -f
+
+# Check what platform plugin is being used
+ps aux | grep marathon-shell
+
+# Test startup script directly
+/usr/local/bin/marathon-shell-session
+```
+
+### 5. Minimal Reproduction
+Tested Marathon Shell in isolation (not through LightDM) to separate compositor issues from session management issues.
+
+## Remaining Challenges
+
+### 1. Remote Access
+- **Challenge**: VNC/XRDP don't work with Wayland compositors by default
+- **Potential Solution**: Integrate `wayvnc` for VNC support
+- **Status**: Not yet implemented
+
+### 2. Boot Time
+- **Current**: ~15 seconds from power to UI
+- **Goal**: < 10 seconds
+- **Potential Optimizations**:
+  - Parallel service startup
+  - Faster QML loading
+  - Pre-compiled QML cache
+
+### 3. Multi-Display Support
+- **Current**: Single display only
+- **Challenge**: Qt eglfs multi-display configuration
+- **Status**: Not tested
+
+## Future Development Ideas
+
+1. **Custom Boot Splash**: Replace Raspberry Pi rainbow screen with Marathon logo
+2. **Hardware Video Acceleration**: Integrate V4L2 for video playback
+3. **Power Management**: Suspend/resume support via systemd-logind
+4. **Touch Calibration UI**: Built-in touch screen calibration tool
+5. **OTA Updates**: System for updating Marathon Shell remotely
+6. **Custom App Store**: Repository of Marathon-optimized apps
+
+## Contributing
+
+If you're working on this project:
+
+1. **Test thoroughly**: Always test on actual hardware before committing
+2. **Document changes**: Update this file with discoveries and solutions
+3. **Preserve backups**: Session files, configs, etc. should have backup copies
+4. **Use version tags**: Tag releases for stability tracking
+
+## References
+
+- [Marathon Shell GitHub](https://github.com/MarathonOS/marathon-shell)
+- [Qt QPA Documentation](https://doc.qt.io/qt-6/qpa.html)
+- [Wayland Protocol Specs](https://wayland.freedesktop.org/docs/html/)
+- [LightDM Configuration](https://wiki.archlinux.org/title/LightDM)
+- [Raspberry Pi DRM/KMS](https://www.raspberrypi.com/documentation/computers/configuration.html#drm-kms)
+
+---
+
+*Last updated: 2025-11-12*
+

--- a/platforms/raspberry-pi/docs/TROUBLESHOOTING.md
+++ b/platforms/raspberry-pi/docs/TROUBLESHOOTING.md
@@ -1,0 +1,473 @@
+# Troubleshooting Guide
+
+This document covers common issues you might encounter when running Marathon Shell on Raspberry Pi and how to resolve them.
+
+## Table of Contents
+
+- [Boot Issues](#boot-issues)
+- [Display Issues](#display-issues)
+- [Session Lock Issues](#session-lock-issues)
+- [Performance Issues](#performance-issues)
+- [Logging and Debugging](#logging-and-debugging)
+
+---
+
+## Boot Issues
+
+### Black Screen After Boot
+
+**Symptoms**: After boot, screen is black with a blinking cursor, but no Marathon Shell UI appears.
+
+**Possible Causes & Solutions**:
+
+1. **LightDM not starting Marathon session**
+   ```bash
+   # Check LightDM status
+   sudo systemctl status lightdm
+   
+   # Check if session is set correctly
+   grep -E "(user-session|autologin-session)" /etc/lightdm/lightdm.conf
+   # Should show: user-session=marathon and autologin-session=marathon
+   
+   # Check session file exists
+   ls -l /usr/share/wayland-sessions/marathon.desktop
+   ```
+
+2. **Marathon Shell binary missing or incorrect**
+   ```bash
+   # Verify binary exists
+   which marathon-shell-bin
+   # Should show: /usr/bin/marathon-shell-bin
+   
+   # Check it's executable
+   ls -l /usr/bin/marathon-shell-bin
+   
+   # Test if it runs
+   /usr/bin/marathon-shell-bin --help
+   ```
+
+3. **GPU/DRM permissions issue**
+   ```bash
+   # Check user is in video/render groups
+   groups $USER
+   # Should include: video render
+   
+   # Add user to groups if missing
+   sudo usermod -a -G video,render $USER
+   
+   # Grant capabilities
+   sudo setcap cap_sys_nice+ep /usr/bin/marathon-shell-bin
+   
+   # Reboot required
+   sudo reboot
+   ```
+
+4. **Qt platform plugin failure**
+   ```bash
+   # Check logs for Qt errors
+   journalctl -u lightdm | grep -i "qt\|platform\|eglfs"
+   
+   # Verify Qt6 is installed
+   dpkg -l | grep qt6
+   
+   # Check EGL/OpenGL libraries
+   ls /usr/lib/aarch64-linux-gnu/libEGL*
+   ls /usr/lib/aarch64-linux-gnu/libGLES*
+   ```
+
+### Returning to Login Screen After Login
+
+**Symptoms**: You log in, see a brief black screen, then return to the LightDM login screen.
+
+**Solution**:
+
+1. **Check if another compositor is conflicting**
+   ```bash
+   # Ensure greeter is X11-based, not Wayland
+   grep "greeter-session" /etc/lightdm/lightdm.conf
+   # Should show: greeter-session=lightdm-gtk-greeter
+   
+   # If it shows pi-greeter-labwc or another Wayland greeter:
+   sudo sed -i 's/greeter-session=.*/greeter-session=lightdm-gtk-greeter/' /etc/lightdm/lightdm.conf
+   sudo apt-get install lightdm-gtk-greeter
+   sudo reboot
+   ```
+
+2. **Session script errors**
+   ```bash
+   # Check session script is executable
+   ls -l /usr/local/bin/marathon-shell-session
+   
+   # Test it manually
+   /usr/local/bin/marathon-shell-session
+   # (Ctrl+C to exit after testing)
+   ```
+
+3. **Check session logs**
+   ```bash
+   # View detailed LightDM session logs
+   sudo journalctl -u lightdm -b | less
+   
+   # Look for Marathon-specific errors
+   grep -i marathon /var/log/lightdm/
+   ```
+
+### Boot Hangs at Rainbow Screen
+
+**Symptoms**: Raspberry Pi shows the rainbow screen but never progresses.
+
+**Solution**:
+
+This is usually unrelated to Marathon Shell. Check:
+
+```bash
+# Boot into recovery mode (hold Shift during boot)
+# Or connect via SSH if network is up
+
+# Check boot partition
+sudo fsck /boot
+
+# Review boot config
+cat /boot/config.txt
+
+# Check kernel messages
+dmesg | less
+```
+
+---
+
+## Display Issues
+
+### Screen Too Small/Too Large (Scaling Issues)
+
+**Solution**:
+
+Edit the session script to adjust Qt scaling:
+
+```bash
+sudo nano /usr/local/bin/marathon-shell-session
+```
+
+Find and modify these lines:
+
+```bash
+# For smaller displays or higher DPI:
+export QT_SCALE_FACTOR=1.5
+
+# For larger displays or lower DPI:
+export QT_SCALE_FACTOR=0.8
+
+# To enable automatic scaling:
+export QT_AUTO_SCREEN_SCALE_FACTOR=1
+```
+
+Reboot after changes.
+
+### Choppy/Laggy Graphics
+
+**Symptoms**: UI animations are stuttering or slow.
+
+**Solutions**:
+
+1. **Verify GPU acceleration is enabled**
+   ```bash
+   # Check that eglfs is being used
+   ps aux | grep marathon-shell-bin
+   # Should show: -platform eglfs
+   ```
+
+2. **Check if running in software rendering mode**
+   ```bash
+   # If it shows -platform linuxfb, edit session script:
+   sudo sed -i 's/-platform linuxfb/-platform eglfs/' /usr/local/bin/marathon-shell-session
+   sudo reboot
+   ```
+
+3. **Enable GPU memory allocation**
+   ```bash
+   # Edit boot config
+   sudo nano /boot/firmware/config.txt
+   
+   # Add or modify:
+   gpu_mem=256
+   
+   # Reboot
+   sudo reboot
+   ```
+
+### No Touch Input
+
+**Symptoms**: Touch screen doesn't respond, but mouse/keyboard works.
+
+**Solutions**:
+
+1. **Check touchscreen device is detected**
+   ```bash
+   # List input devices
+   ls /dev/input/event*
+   
+   # Check if touchscreen is recognized
+   dmesg | grep -i touch
+   ```
+
+2. **Verify Qt touch input is enabled**
+   ```bash
+   # Add to session script
+   sudo nano /usr/local/bin/marathon-shell-session
+   
+   # Add these lines before the exec command:
+   export QT_QPA_EGLFS_INTEGRATION=eglfs_kms
+   export QT_QPA_ENABLE_TERMINAL_KEYBOARD=1
+   export QT_QPA_EVDEV_TOUCHSCREEN_PARAMETERS=/dev/input/event0
+   ```
+
+---
+
+## Session Lock Issues
+
+### Immediate Re-Lock After Unlock
+
+**Symptoms**: You swipe up and enter the PIN, but Marathon Shell immediately locks again.
+
+**Solution**:
+
+This should be fixed by the patches included in this repository. Verify patches are applied:
+
+```bash
+# Check SessionManager has the fix
+grep "property double lastActivityTime" ~/Marathon-Shell/shell/qml/services/SessionManager.qml
+
+# Should return:
+#   property double lastActivityTime: Date.now()
+# NOT:
+#   property int lastActivityTime: 0
+
+# If still showing 'int', re-apply patches:
+cd ~/Marathon-Shell
+patch -p1 < ~/marathon-hackberry-pi/patches/01-sessionmanager-fix.patch
+cd build
+ninja install
+sudo reboot
+```
+
+### Screen Doesn't Lock at All
+
+**Symptoms**: Marathon Shell never locks, even after hours of inactivity.
+
+**Solutions**:
+
+1. **Check idle detection is enabled**
+   ```bash
+   # Edit SessionManager.qml
+   nano ~/Marathon-Shell/shell/qml/services/SessionManager.qml
+   
+   # Verify this line:
+   property bool idleDetectionEnabled: true
+   ```
+
+2. **Check timeout values**
+   ```bash
+   # In SessionManager.qml:
+   property int idleTimeout: 3600000  // 1 hour in milliseconds
+   property int lockTimeout: 3600000  // Additional time before lock
+   
+   # For testing, temporarily reduce to 30 seconds:
+   property int idleTimeout: 30000  // 30 seconds
+   ```
+
+3. **Rebuild after changes**
+   ```bash
+   cd ~/Marathon-Shell/build
+   ninja install
+   sudo systemctl restart lightdm
+   ```
+
+### Can't Unlock - Swipe Not Working
+
+**Symptoms**: Swipe gesture on lock screen doesn't work.
+
+**Solutions**:
+
+1. **Test with mouse instead of touch**
+   - Click and drag upward on the lock screen
+
+2. **Check touch calibration**
+   ```bash
+   # Test touch input
+   sudo evtest
+   # Select your touch device and test if events are firing
+   ```
+
+3. **Try PIN screen instead**
+   - If swipe-to-unlock isn't working, the PIN screen should still appear after swiping
+
+---
+
+## Performance Issues
+
+### High CPU Usage
+
+**Symptoms**: Marathon Shell uses 50%+ CPU even when idle.
+
+**Solutions**:
+
+1. **Check QML disk cache**
+   ```bash
+   # Ensure QML cache is enabled
+   ls ~/.cache/marathon-qml/
+   
+   # Clear cache and regenerate
+   rm -rf ~/.cache/marathon-qml/*
+   # Restart Marathon Shell
+   ```
+
+2. **Disable debug logging**
+   ```bash
+   # Edit session script
+   sudo nano /usr/local/bin/marathon-shell-session
+   
+   # Ensure this is NOT set:
+   # MARATHON_DEBUG=1
+   
+   # Should use:
+   export QT_LOGGING_RULES="*.warning=true;marathon.*.info=true"
+   ```
+
+3. **Check for background processes**
+   ```bash
+   # See what Marathon Shell is doing
+   sudo strace -p $(pgrep marathon-shell)
+   ```
+
+### High Memory Usage
+
+**Symptoms**: Marathon Shell uses >1GB of RAM.
+
+**Solutions**:
+
+1. **Close unused apps**
+   - Use the app switcher (swipe from bottom edge) to close apps
+
+2. **Reduce QML cache size**
+   ```bash
+   # Clear cache
+   rm -rf ~/.cache/marathon-qml/*
+   ```
+
+3. **Monitor memory usage**
+   ```bash
+   # Check Marathon Shell memory
+   ps aux | grep marathon-shell
+   
+   # Detailed memory breakdown
+   sudo pmap $(pgrep marathon-shell)
+   ```
+
+---
+
+## Logging and Debugging
+
+### Enable Full Debug Logging
+
+```bash
+# Method 1: Environment variable
+MARATHON_DEBUG=1 /usr/local/bin/marathon-shell-session
+
+# Method 2: Temporary edit to session script
+sudo sed -i 's/MARATHON_DEBUG="0"/MARATHON_DEBUG="1"/' /usr/local/bin/marathon-shell-session
+sudo systemctl restart lightdm
+# (Remember to revert after debugging)
+```
+
+### View Marathon Shell Logs
+
+```bash
+# View current session logs
+journalctl -u lightdm -f
+
+# View logs since last boot
+journalctl -u lightdm -b
+
+# View last 100 lines
+journalctl -u lightdm -n 100
+
+# Search for specific errors
+journalctl -u lightdm | grep -i "error\|warning\|failed"
+
+# Export logs to file
+journalctl -u lightdm -b > ~/marathon-shell-debug.log
+```
+
+### Debug Specific Components
+
+```bash
+# Test Marathon Shell directly (not through LightDM)
+cd ~/Marathon-Shell
+QT_DEBUG_PLUGINS=1 /usr/bin/marathon-shell-bin -platform eglfs
+
+# Test with specific logging categories
+QT_LOGGING_RULES="marathon.session.debug=true" /usr/bin/marathon-shell-bin -platform eglfs
+
+# Test in nested mode (within existing desktop)
+WAYLAND_DISPLAY=wayland-0 /usr/bin/marathon-shell-bin -platform wayland --fullscreen
+```
+
+### Get System Information
+
+```bash
+# Raspberry Pi model
+cat /proc/device-tree/model
+
+# Qt version
+qmake6 --version
+
+# OpenGL/EGL info
+glxinfo | grep "OpenGL"
+
+# Wayland compositor info
+echo $WAYLAND_DISPLAY
+echo $XDG_SESSION_TYPE
+
+# All environment variables
+env | sort
+```
+
+---
+
+## Getting Help
+
+If you're still experiencing issues:
+
+1. **Collect debug information**:
+   ```bash
+   # Create a debug report
+   echo "=== System Info ===" > ~/marathon-debug-report.txt
+   cat /proc/device-tree/model >> ~/marathon-debug-report.txt
+   uname -a >> ~/marathon-debug-report.txt
+   echo "" >> ~/marathon-debug-report.txt
+   
+   echo "=== Marathon Shell Version ===" >> ~/marathon-debug-report.txt
+   /usr/bin/marathon-shell-bin --version >> ~/marathon-debug-report.txt
+   echo "" >> ~/marathon-debug-report.txt
+   
+   echo "=== LightDM Logs ===" >> ~/marathon-debug-report.txt
+   journalctl -u lightdm -b | tail -100 >> ~/marathon-debug-report.txt
+   
+   echo "=== Configuration ===" >> ~/marathon-debug-report.txt
+   cat /etc/lightdm/lightdm.conf >> ~/marathon-debug-report.txt
+   ```
+
+2. **Open a GitHub issue** with:
+   - Description of the problem
+   - Steps to reproduce
+   - Your debug report
+   - Screenshots/video if applicable
+
+3. **Check existing issues**:
+   - [Marathon Shell Issues](https://github.com/MarathonOS/marathon-shell/issues)
+   - [This Repository Issues](https://github.com/YOUR_USERNAME/marathon-hackberry-pi/issues)
+
+---
+
+*Last updated: 2025-11-12*
+

--- a/platforms/raspberry-pi/scripts/install.sh
+++ b/platforms/raspberry-pi/scripts/install.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+# Marathon Shell on Hackberry Pi - Automated Installation Script
+# This script installs and configures Marathon Shell as the default desktop environment
+
+set -e  # Exit on error
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}"
+echo "╔════════════════════════════════════════════════════════╗"
+echo "║   Marathon Shell on Hackberry Pi - Installation       ║"
+echo "║   BlackBerry BB10 Successor on Raspberry Pi           ║"
+echo "╚════════════════════════════════════════════════════════╝"
+echo -e "${NC}"
+
+# Check if running on Raspberry Pi
+if [ ! -f /proc/device-tree/model ] || ! grep -q "Raspberry Pi" /proc/device-tree/model; then
+    echo -e "${YELLOW}Warning: This doesn't appear to be a Raspberry Pi${NC}"
+    read -p "Continue anyway? (y/n) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        exit 1
+    fi
+fi
+
+# Check if Marathon Shell is installed
+if [ ! -f /usr/bin/marathon-shell-bin ]; then
+    echo -e "${RED}Error: Marathon Shell binary not found at /usr/bin/marathon-shell-bin${NC}"
+    echo "Please compile and install Marathon Shell first."
+    echo "See: https://github.com/MarathonOS/marathon-shell#building"
+    exit 1
+fi
+
+# Check if Marathon Shell source directory exists
+if [ ! -d "$HOME/Marathon-Shell" ]; then
+    echo -e "${YELLOW}Warning: Marathon Shell source not found at $HOME/Marathon-Shell${NC}"
+    echo "Patches cannot be applied. Please update the path if Marathon Shell is installed elsewhere."
+    read -p "Continue without applying patches? (y/n) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        exit 1
+    fi
+    SKIP_PATCHES=1
+fi
+
+# Get script directory
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+
+echo -e "${GREEN}=== Step 1: Backing up existing configuration ===${NC}"
+
+# Backup LightDM config
+if [ -f /etc/lightdm/lightdm.conf ]; then
+    sudo cp /etc/lightdm/lightdm.conf /etc/lightdm/lightdm.conf.backup.$(date +%Y%m%d_%H%M%S)
+    echo "✓ Backed up /etc/lightdm/lightdm.conf"
+fi
+
+# Backup existing marathon session files if they exist
+if [ -f /usr/local/bin/marathon-shell-session ]; then
+    sudo cp /usr/local/bin/marathon-shell-session /usr/local/bin/marathon-shell-session.backup.$(date +%Y%m%d_%H%M%S)
+    echo "✓ Backed up /usr/local/bin/marathon-shell-session"
+fi
+
+if [ -f /usr/share/wayland-sessions/marathon.desktop ]; then
+    sudo cp /usr/share/wayland-sessions/marathon.desktop /usr/share/wayland-sessions/marathon.desktop.backup.$(date +%Y%m%d_%H%M%S)
+    echo "✓ Backed up /usr/share/wayland-sessions/marathon.desktop"
+fi
+
+if [ "$SKIP_PATCHES" != "1" ]; then
+    echo -e "\n${GREEN}=== Step 2: Applying QML patches ===${NC}"
+    
+    cd "$HOME/Marathon-Shell"
+    
+    # Check if patches are already applied
+    if grep -q "property double lastActivityTime" shell/qml/services/SessionManager.qml; then
+        echo "✓ SessionManager patch already applied"
+    else
+        echo "Applying SessionManager patch..."
+        patch -p1 < "$REPO_DIR/patches/01-sessionmanager-fix.patch"
+        echo "✓ Applied SessionManager patch"
+    fi
+    
+    # Check if SessionStore patch is needed
+    if grep -q "30 second guard" shell/qml/stores/SessionStore.qml; then
+        echo "Applying SessionStore patch..."
+        patch -p1 < "$REPO_DIR/patches/02-sessionstore-fix.patch"
+        echo "✓ Applied SessionStore patch"
+    else
+        echo "✓ SessionStore patch already applied or not needed"
+    fi
+    
+    # Rebuild Marathon Shell
+    echo -e "\n${BLUE}Rebuilding Marathon Shell...${NC}"
+    if [ -d build ]; then
+        cd build
+        ninja install
+        echo "✓ Marathon Shell rebuilt and installed"
+    else
+        echo -e "${YELLOW}Warning: build directory not found. Please rebuild Marathon Shell manually:${NC}"
+        echo "  cd ~/Marathon-Shell/build"
+        echo "  ninja install"
+    fi
+else
+    echo -e "\n${YELLOW}=== Step 2: Skipping patches (source not found) ===${NC}"
+fi
+
+echo -e "\n${GREEN}=== Step 3: Installing session files ===${NC}"
+
+# Install session startup script
+sudo cp "$REPO_DIR/config/marathon-shell-session" /usr/local/bin/
+sudo chmod +x /usr/local/bin/marathon-shell-session
+echo "✓ Installed /usr/local/bin/marathon-shell-session"
+
+# Install desktop entry
+sudo mkdir -p /usr/share/wayland-sessions
+sudo cp "$REPO_DIR/config/marathon.desktop" /usr/share/wayland-sessions/
+echo "✓ Installed /usr/share/wayland-sessions/marathon.desktop"
+
+echo -e "\n${GREEN}=== Step 4: Configuring LightDM ===${NC}"
+
+# Install LightDM configuration
+sudo cp "$REPO_DIR/config/lightdm.conf" /etc/lightdm/
+echo "✓ Installed LightDM configuration"
+
+# Ensure lightdm-gtk-greeter is installed
+if ! dpkg -l | grep -q lightdm-gtk-greeter; then
+    echo "Installing lightdm-gtk-greeter..."
+    sudo apt-get update
+    sudo apt-get install -y lightdm-gtk-greeter
+fi
+
+echo -e "\n${GREEN}=== Step 5: Setting up permissions ===${NC}"
+
+# Add user to video and render groups
+sudo usermod -a -G video,render $USER
+echo "✓ Added $USER to video,render groups"
+
+# Grant capabilities to Marathon Shell
+sudo setcap cap_sys_nice+ep /usr/bin/marathon-shell-bin
+echo "✓ Granted Marathon Shell real-time priority capability"
+
+echo -e "\n${GREEN}╔════════════════════════════════════════════════════════╗${NC}"
+echo -e "${GREEN}║            Installation Complete! 🎉                   ║${NC}"
+echo -e "${GREEN}╚════════════════════════════════════════════════════════╝${NC}"
+
+echo -e "\n${BLUE}Marathon Shell is now configured as your default desktop environment.${NC}"
+echo -e "\n${YELLOW}Please reboot to start using Marathon Shell:${NC}"
+echo -e "  ${GREEN}sudo reboot${NC}"
+
+echo -e "\n${BLUE}After reboot:${NC}"
+echo "  • Marathon Shell will start automatically"
+echo "  • Swipe up on the lock screen to unlock"
+echo "  • Auto-lock after 1 hour of inactivity"
+echo "  • GPU-accelerated rendering (eglfs)"
+
+echo -e "\n${YELLOW}Troubleshooting:${NC}"
+echo "  • If you see a black screen, press Ctrl+Alt+F2 for a terminal"
+echo "  • Check logs: journalctl -u lightdm | tail -50"
+echo "  • See docs/TROUBLESHOOTING.md for common issues"
+
+echo -e "\n${BLUE}To restore the original Raspberry Pi desktop:${NC}"
+echo -e "  ${GREEN}./scripts/uninstall.sh${NC}"
+
+echo -e "\n${GREEN}Enjoy your BlackBerry BB10 successor! 📱✨${NC}"
+

--- a/platforms/raspberry-pi/scripts/uninstall.sh
+++ b/platforms/raspberry-pi/scripts/uninstall.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Marathon Shell on Hackberry Pi - Uninstall Script
+# Restores the original Raspberry Pi desktop environment
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+echo -e "${YELLOW}"
+echo "╔════════════════════════════════════════════════════════╗"
+echo "║   Marathon Shell - Uninstall                           ║"
+echo "║   Restore Raspberry Pi Desktop                         ║"
+echo "╚════════════════════════════════════════════════════════╝"
+echo -e "${NC}"
+
+echo -e "${RED}This will restore your Raspberry Pi to the default desktop environment.${NC}"
+read -p "Continue? (y/n) " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    exit 1
+fi
+
+echo -e "\n${GREEN}=== Step 1: Restoring LightDM configuration ===${NC}"
+
+# Find most recent backup
+BACKUP=$(ls -t /etc/lightdm/lightdm.conf.backup.* 2>/dev/null | head -1)
+
+if [ -n "$BACKUP" ]; then
+    sudo cp "$BACKUP" /etc/lightdm/lightdm.conf
+    echo "✓ Restored LightDM config from: $BACKUP"
+else
+    echo -e "${YELLOW}Warning: No backup found. Resetting to default Raspberry Pi session...${NC}"
+    sudo sed -i 's/^user-session=marathon/user-session=LXDE-pi-wayfire/' /etc/lightdm/lightdm.conf
+    sudo sed -i 's/^autologin-session=marathon/autologin-session=LXDE-pi-wayfire/' /etc/lightdm/lightdm.conf
+    sudo sed -i 's/^greeter-session=lightdm-gtk-greeter/#greeter-session=lightdm-gtk-greeter/' /etc/lightdm/lightdm.conf
+    echo "✓ Reset to default session"
+fi
+
+echo -e "\n${GREEN}=== Step 2: Keeping Marathon Shell files (optional removal) ===${NC}"
+
+echo "Marathon Shell files remain installed in case you want to use it again."
+echo "To completely remove Marathon Shell:"
+echo "  sudo rm /usr/local/bin/marathon-shell-session"
+echo "  sudo rm /usr/share/wayland-sessions/marathon.desktop"
+echo "  sudo rm /usr/bin/marathon-shell-bin"
+
+echo -e "\n${GREEN}╔════════════════════════════════════════════════════════╗${NC}"
+echo -e "${GREEN}║            Uninstallation Complete!                    ║${NC}"
+echo -e "${GREEN}╚════════════════════════════════════════════════════════╝${NC}"
+
+echo -e "\n${YELLOW}Please reboot to return to the Raspberry Pi desktop:${NC}"
+echo -e "  ${GREEN}sudo reboot${NC}"
+
+echo -e "\n${BLUE}To reinstall Marathon Shell later:${NC}"
+echo -e "  ${GREEN}./scripts/install.sh${NC}"
+


### PR DESCRIPTION
This adds comprehensive support for running Marathon Shell on Raspberry Pi devices (CM4, CM5, Pi 4, Pi 5). Successfully tested on Hackberry Pi with Raspberry Pi CM5.

Key features:
- Automated installation script for easy setup
- LightDM integration with auto-login support
- Wayland session configuration optimized for Pi
- GPU-accelerated rendering using Qt eglfs platform
- Touch-optimized mobile interface

Platform structure:
- config/ - System configuration files (LightDM, session startup)
- scripts/ - Installation and uninstall automation
- docs/ - Architecture, troubleshooting, and development guides

The session startup script intelligently detects whether it's running as a primary compositor or nested, selecting the appropriate Qt platform plugin (eglfs for standalone, wayland for nested).

Hardware requirements:
- Raspberry Pi 4 or newer
- 2GB+ RAM recommended
- Display via HDMI/DSI
- GPU with OpenGL ES 2.0+

Performance is excellent on CM5 hardware with proper GPU acceleration.