### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ elseif(UNIX)
     message(STATUS "Using system Qt6 at ${Qt6_DIR}")
 endif()
 
-find_package(Qt6 6.4...6.10.1 REQUIRED COMPONENTS
+find_package(Qt6 6.4 REQUIRED COMPONENTS
     Core
     Gui
     Widgets


### PR DESCRIPTION
  Could not find a configuration file for package "Qt6" that is compatible
  with requested version range "6.4...6.10.1".

  The following configuration files were considered but not accepted:

    /usr/lib/cmake/Qt6/Qt6Config.cmake, version: 6.11.0
      The version found is not compatible with the version requested.

- Qt6 version limit has to be removed to build on edge.